### PR TITLE
add `npm install` instruction for wasm-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The full client is currently a work in progress and doesn't support many feature
 
 Pre-requisite: in order to run the wasm light node, you must have installed [rustup](https://rustup.rs/).
 
-The wasm light node can be tested with `cd bin/wasm-node/javascript` and `npm start`. This will compile the smoldot wasm light node and start a WebSocket server capable of answering JSON-RPC requests. You can then navigate to <https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944> in order to interact with the Westend chain.
+The wasm light node can be tested with `cd bin/wasm-node/javascript` and `npm install; npm start`. This will compile the smoldot wasm light node and start a WebSocket server capable of answering JSON-RPC requests. You can then navigate to <https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944> in order to interact with the Westend chain.
 
 > Note: The `npm start` command starts a small JavaScript shim, on top of the wasm light node, that hardcodes the chain to Westend and starts the WebSocket server. The wasm light node itself can connect to a variety of different chains (not only Westend) and doesn't start any server.
 


### PR DESCRIPTION
if we don't tell the user to explicitly use `npm install`, they might run into:
```
    Finished dev [optimized + debuginfo] target(s) in 3m 24s
internal/process/esm_loader.js:74
    internalBinding('errors').triggerUncaughtException(
                              ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'websocket' imported from /home/bear/develop/parity/smoldot/bin/wasm-node/javascript/demo/demo.js
    at new NodeError (internal/errors.js:322:7)
    at packageResolve (internal/modules/esm/resolve.js:687:9)
    at moduleResolve (internal/modules/esm/resolve.js:728:18)
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:842:11)
    at Loader.resolve (internal/modules/esm/loader.js:89:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:242:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:76:40)
    at link (internal/modules/esm/module_job.js:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @substrate/smoldot-light@0.4.18 start: `node prepare.js --debug && node demo/demo.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @substrate/smoldot-light@0.4.18 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/bear/.npm/_logs/2021-10-16T02_53_52_914Z-debug.log
```

by running `npm install` before `npm start`, I was able to start the wasm-node without problems.